### PR TITLE
Fix endless waiting for file write

### DIFF
--- a/src/Generator.php
+++ b/src/Generator.php
@@ -231,10 +231,10 @@ final readonly class Generator
 
                 file_put_contents($fileName, $fileContents);
                 $this->state->generatedFiles->upsert($fileName, $fileContentsHash);
-            }
 
-            while (! file_exists($fileName) || $fileContentsHash !== md5(file_get_contents($fileName))) {
-                usleep(100);
+                while (! file_exists($fileName) || $fileContentsHash !== md5(file_get_contents($fileName))) {
+                    usleep(100);
+                }
             }
 
             include_once $fileName;


### PR DESCRIPTION
The wait should only happen when the file is written, not when it was already there and might have changed.